### PR TITLE
Add test, stan::lang::compile given invalid code

### DIFF
--- a/src/protostan/lang/compiler.hpp
+++ b/src/protostan/lang/compiler.hpp
@@ -8,16 +8,16 @@ namespace stan {
   namespace proto {
     stan::proto::StanCompileResponse compile(
       const stan::proto::StanCompileRequest& request) {
-        stan::proto::StanCompileResponse response;
-        std::ostringstream err_stream;
-        std::istringstream stan_stream(request.model_code());
-        std::ostringstream cpp_stream;
 
+      stan::proto::StanCompileResponse response;
+      std::ostringstream err_stream;
+      std::istringstream stan_stream(request.model_code());
+      std::ostringstream cpp_stream;
+
+      try {
         bool valid_model = stan::lang::compile(&err_stream,
           stan_stream, cpp_stream,
           request.model_name(), request.model_file_name());
-        response.set_messages(err_stream.str());
-        response.set_cpp_code(cpp_stream.str());
         if (valid_model) {
           if (err_stream.tellp() == 0)
             response.set_state(stan::proto::StanCompileResponse::SUCCESS);
@@ -26,10 +26,12 @@ namespace stan {
         } else {
           response.set_state(stan::proto::StanCompileResponse::ERROR);
         }
-          return response;
+      } catch(const std::exception& e) {
+        response.set_state(stan::proto::StanCompileResponse::ERROR);
       }
+      response.set_messages(err_stream.str());
+      response.set_cpp_code(cpp_stream.str());
+      return response;
+    }
   }
 }
-
-
-

--- a/src/protostan/lang/compiler.hpp
+++ b/src/protostan/lang/compiler.hpp
@@ -6,22 +6,22 @@
 
 namespace stan {
   namespace proto {
-    stan::proto::StanCompileResponse compile( 
+    stan::proto::StanCompileResponse compile(
       const stan::proto::StanCompileRequest& request) {
         stan::proto::StanCompileResponse response;
         std::ostringstream err_stream;
         std::istringstream stan_stream(request.model_code());
         std::ostringstream cpp_stream;
-        
-        bool valid_model = stan::lang::compile(&err_stream, 
-          stan_stream, cpp_stream, 
+
+        bool valid_model = stan::lang::compile(&err_stream,
+          stan_stream, cpp_stream,
           request.model_name(), request.model_file_name());
         response.set_messages(err_stream.str());
         response.set_cpp_code(cpp_stream.str());
         if (valid_model) {
-          if (err_stream.tellp() == 0) 
+          if (err_stream.tellp() == 0)
             response.set_state(stan::proto::StanCompileResponse::SUCCESS);
-          else 
+          else
             response.set_state(stan::proto::StanCompileResponse::WARN);
         } else {
           response.set_state(stan::proto::StanCompileResponse::ERROR);

--- a/src/test/stanc-test.cpp
+++ b/src/test/stanc-test.cpp
@@ -4,12 +4,11 @@
 TEST(stanc, minimumModelCompile) {
   stan::proto::StanCompileRequest request;
   stan::proto::StanCompileResponse response;
-  
+
   request.set_model_name("test");
   request.set_model_code("model {}");
   request.set_model_file_name("test.stan");
   response = stan::proto::compile(request);
-  std::cout << response.cpp_code() << std::endl;
   // FIXME: These tests are lame, but that's all that
   // stan-dev/stan does... (?)
   EXPECT_EQ(2, response.state());

--- a/src/test/stanc-test.cpp
+++ b/src/test/stanc-test.cpp
@@ -16,6 +16,20 @@ TEST(stanc, minimumModelCompile) {
   EXPECT_EQ(std::string::npos, response.cpp_code().find("int main("));
 }
 
+
+TEST(stanc, invalidModelCompile) {
+  stan::proto::StanCompileRequest request;
+  stan::proto::StanCompileResponse response;
+
+  request.set_model_name("test");
+  request.set_model_code("invalid model code");
+  request.set_model_file_name("test.stan");
+  response = stan::proto::compile(request);
+  EXPECT_EQ(4, response.state());
+  EXPECT_EQ("", response.messages());
+  EXPECT_EQ(std::string::npos, response.cpp_code().find("int main("));
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   int returnValue;


### PR DESCRIPTION
Wondering if WARN needs to be a separate status. Whoever is using protostan should check to see if there are warning messages (i.e., that messages is not an empty string). Will add some other inline comments.