### PR TITLE
Remove model_file_name from StanCompileRequest

### DIFF
--- a/proto/compile.proto
+++ b/proto/compile.proto
@@ -8,7 +8,6 @@ package stan.proto;
 message StanCompileRequest {
   string model_name = 1;      /// Name of the Stan model.
   string model_code = 2;      /// Stan-language code for the model.
-  string model_file_name = 3; /// Name of the Stan model file, for error messages.
 }
 
 /**

--- a/src/protostan/lang/compiler.hpp
+++ b/src/protostan/lang/compiler.hpp
@@ -18,8 +18,7 @@ namespace stan {
         bool valid_model = stan::lang::compile(&err_stream,
                                                stan_stream,
                                                cpp_stream,
-                                               request.model_name(),
-                                               request.model_file_name());
+                                               request.model_name());
         response.set_messages(err_stream.str());
         if (valid_model) {
           response.set_state(stan::proto::StanCompileResponse::SUCCESS);


### PR DESCRIPTION
model_file_name is not used in Stan. It's an artifact of old code.

See Stan stan-dev/stan#1752

Closes #16 and #13.
