### PR TITLE
Added documentation and some usage comments.  

### DIFF
--- a/src/protostan/interface_callbacks/writer/binary_proto_stream_writer.hpp
+++ b/src/protostan/interface_callbacks/writer/binary_proto_stream_writer.hpp
@@ -14,18 +14,28 @@ namespace stan {
     namespace writer {
 
       /**
-       * binary_proto_stream_writer writes to an std::ostream.
+       * binary_proto_stream_writer writes a stan::proto::StanMessage to
+       * a google::protobuf::io::ZeroCopyOutputStream (or subclass).
+       * Re-uses a single private message across all its methods to
+       * avoid repeated construction/destruction of messages.  The
+       * message is Clear()-ed at the beginning of each method to avoid
+       * bringing cruft from a previous call.  
+       *
+       * The output format is basically a key/index/value format and the
+       * writer could keep track of additional information (e.g., for
+       * parameter output in samples the iteration could be recorded as
+       * well.  What additional data should be tracked?
        */
       template <bool (*F)(
         google::protobuf::MessageLite*, google::protobuf::io::ZeroCopyOutputStream*)>
       class binary_proto_stream_writer : public base_writer {
       public:
         /**
-         * Constructor. Takes ownership of the pointer argument.
+         * Constructor.
          *
-         * @param output pointer to a ZeroCopyOutputStream (sublcass) to 
-         *               write to.  The object now owns the pointer and 
-         *               will delete on destruction.  
+         * @param[in] output pointer to a ZeroCopyOutputStream, the
+         *   ojbect takes ownership (will delete) the stream on
+         *   destruction.
          */
         binary_proto_stream_writer(
           google::protobuf::io::ZeroCopyOutputStream* output) : 
@@ -35,21 +45,53 @@ namespace stan {
           delete raw_output__;
         }
 
+        /**
+         * The key/value(double) combination is written as PARAMETER_OUTPUT type
+         * of message.  I don't really know when this version of the
+         * call is currently used. Should there be a specific message
+         * type?  Should the writer track more information to add to the
+         * message?
+         *  @param[in] key 
+         *  @param[in] value double to write.
+         */
         void operator()(const std::string& key, double value) {
+          stan_message__.Clear();
           stan_message__.set_type(stan::proto::StanMessage::PARAMETER_OUTPUT);
           stan_message__.mutable_stan_parameter_output()->set_key(key);
           stan_message__.mutable_stan_parameter_output()->set_value(value);
           write();
         }
 
+        /**
+         * The key/value(int) combination is written as INTEGER_OUTPUT type
+         * of message.  I don't really know when this version of the
+         * call is currently used. Should there be a specific message
+         * type?  Should the writer track more information to add to the
+         * message?  I think this is used to output info on control
+         * (input) parameters in CmdStan...
+         *  @param[in] key 
+         *  @param[in] value integer to write.
+         */
         void operator()(const std::string& key, int value) {
+          stan_message__.Clear();
           stan_message__.set_type(stan::proto::StanMessage::INTEGER_OUTPUT);
           stan_message__.mutable_stan_integer_output()->set_key(key);
           stan_message__.mutable_stan_integer_output()->set_value(value);
           write();
         }
 
+        /**
+         * The key/value(string) combination is written as STRING_OUTPUT type
+         * of message.  I don't really know when this version of the
+         * call is currently used. Should there be a specific message
+         * type?  Should the writer track more information to add to the
+         * message?  I think this is used to output info on control
+         * (input) data?
+         *  @param[in] key 
+         *  @param[in] value integer to write.
+         */
         void operator()(const std::string& key, const std::string& value) {
+          stan_message__.Clear();
           stan_message__.set_type(stan::proto::StanMessage::STRING_OUTPUT);
           stan_message__.mutable_stan_string_output()->set_key(key);
           stan_message__.mutable_stan_string_output()->set_value(value);
@@ -61,6 +103,7 @@ namespace stan {
                         int n_values) {
           if (n_values == 0) return;
 
+          stan_message__.Clear();
           stan_message__.set_type(stan::proto::StanMessage::PARAMETER_OUTPUT);
           stan_message__.mutable_stan_parameter_output()->set_key(key);
           stan_message__.mutable_stan_parameter_output()->add_indexing(0);
@@ -73,11 +116,23 @@ namespace stan {
 
         }
 
+        /**
+         * The key/values(double*)/int/int combination is written as
+         * PARAMETER_OUTPUT.  I don't think this is used to output
+         * sampled parameters but rather write out the mass matrix or
+         * something like that.  Should there be a more specific message
+         * type?  Additional info to track?
+         * @param[in] key
+         * @param[in] values pointer to array of values to output.
+         * @param[in] n_rows number of rows in the (implied) matrix.
+         * @param[in] n_cols number of columns in the (implied) matrix.
+         */
         void operator()(const std::string& key,
                         const double* values,
                         int n_rows, int n_cols) {
           if (n_rows == 0 || n_cols == 0) return;
 
+          stan_message__.Clear();
           stan_message__.set_type(stan::proto::StanMessage::PARAMETER_OUTPUT);
           stan_message__.mutable_stan_parameter_output()->set_key(key);
           stan_message__.mutable_stan_parameter_output()->add_indexing(-1);
@@ -93,10 +148,17 @@ namespace stan {
           }
         }
 
+        /**
+         * The vector<string> operator writes out the names of
+         * parameters (in CmdStan anyway).  I think this message type is
+         * appropriate and contains enough information.
+         * @param [in] names vector of parameter names to write.
+         */
         void operator()(const std::vector<std::string>& names) {
           if (names.empty()) return;
           int idx = 0;
 
+          stan_message__.Clear();
           stan_message__.set_type(stan::proto::StanMessage::STRING_OUTPUT);
           stan_message__.mutable_stan_string_output()->set_key("name");
           stan_message__.mutable_stan_string_output()->add_indexing(-1);
@@ -110,10 +172,16 @@ namespace stan {
           }
         }
 
+        /**
+         * The vector<double> operator writes out the sampled/optimized
+         * parameter values at each iteration/whatever.  This message
+         * type could use iteration information added into it.  
+         * @param [in]  values of parameters to write.
         void operator()(const std::vector<double>& state) {
           if (state.empty()) return;
           int idx = 0;
 
+          stan_message__.Clear();
           stan_message__.set_type(stan::proto::StanMessage::PARAMETER_OUTPUT);
           stan_message__.mutable_stan_parameter_output()->set_key("value");
           stan_message__.mutable_stan_parameter_output()->add_indexing(-1);
@@ -127,9 +195,18 @@ namespace stan {
           }
         }
 
+        /**
+         * I'm not even sure why this is here, is there something wrong
+         * with leaving it undefined?
+         */
         void operator()() { }
 
+        /**
+         * The string operator writes out messages, The message type and
+         * info seem appropriate, although maybe the program/model name
+         * could be included.
         void operator()(const std::string& message) {
+          stan_message__.Clear();
           stan_message__.set_type(stan::proto::StanMessage::STRING_OUTPUT);
           stan_message__.mutable_stan_string_output()->set_key("message");
           stan_message__.mutable_stan_string_output()->set_value(message);
@@ -141,6 +218,11 @@ namespace stan {
         stan::proto::StanMessage stan_message__;
         bool success__;
 
+        /**
+         * Here we do the writing with whatever function go passed to
+         * the template.  The type is bool:
+         *   (*F)(messageLite*, * zeroCopyOutputStream)
+         */
         void write() {
           success__ = F(&stan_message__, raw_output__);
         }

--- a/src/protostan/util/rw_delimited_pb.hpp
+++ b/src/protostan/util/rw_delimited_pb.hpp
@@ -10,6 +10,17 @@
 namespace stan {
   namespace proto {
 
+    /**
+     * Write the message pointed to by the first argument to the stream
+     * specified by the second argument, prefixed by a
+     * google::protobuf::Varint32 which indicates the length of the
+     * message. No copies anywhere.
+     *  @param[in] message Pointer to the message to be written out, the
+     *    message can be either Message or MessageLite.
+     *  @param[in] raw_output Pointer to the stream to write to, the
+     *    stream pointed to can be any subclass of ZeroCopyOutputStream. 
+     *  @return true on success and false on any failures.
+     */
     bool write_delimited_pb(
         google::protobuf::MessageLite* message,
         google::protobuf::io::ZeroCopyOutputStream* raw_output
@@ -21,6 +32,21 @@ namespace stan {
       return true;
     }
 
+    /** 
+     * Read data into the message pointed to by the first argument into
+     * the input steam pointed to by the second argument.  First a
+     * google::protobuf::Varint32 is read from the stream and it
+     * indicates how many bytes will be read from the stream.  Then the
+     * message data is read from the stream and merged into the message.
+     * The message must be cleared prior to merging as otherwise
+     * repeated fields are appended rather than replaced.  At the end of
+     * hte operation the next item on the stream should be the Varint32
+     * indicating the length of the subsequent message.
+     *  @param[in] message Pointer to the message to merge data into.
+     *  @param[in] raw_input Pointer to the ZeroCopyInputStream to read
+     *    from. Stream pointed to can be any subclass of
+     *    ZeroCopyInputStream.
+     *  @return true on success and false on any failures.
     bool read_delimited_pb(
         google::protobuf::MessageLite* message,
         google::protobuf::io::ZeroCopyInputStream* raw_input

--- a/src/test/binary_proto_filestream_writer-test.cpp
+++ b/src/test/binary_proto_filestream_writer-test.cpp
@@ -8,15 +8,21 @@
 #include <fcntl.h>
 #include <random>
 
-// This test instantiates writer/ofs explicitely as pointers to control
-// their lifetime s.t. the buffer internal to the writer is flushed
-// correctly prior to attempting a read and so that the writer can flush
-// the ofstream buffer correctly.  This is not an efficient way to write
-// to file as there are two layers of buffering.  The correct way to do
-// it is to do a class ("binary_proto_file_writer") that uses a
-// FileOutputStream on the inside as it's ZeroCopyOutputStream type.
-// This is just to have a test.
-//
+/*
+ * These tests instantiate the streams using pointer/new and the writer
+ * using pointer/new in order to control object lifetime and stream
+ * flushing.  This is not the right way to use them in other code where
+ * a stream is flushed on destruction and read by a separate process.
+ * In general the writer should be instantiated as (probably with a
+ * typedef in here somewhere):
+ *
+ * stan::interface_callbacks::writer::binary_proto_stream_writer<stan::proto::write_delimited_pb> writer(ostream);
+ *
+ * where ostream is a ZeroCopyOutputStream (or subclass), here a
+ * FileOuptutStream constructed from a file descriptor.  The
+ * ZeroCopyOutputStream will be deleted by the writer destructor. The
+ * file descriptor must be closed independently of the writer's destruction.
+ */
 TEST(binaryProtoFileWriter,roundTripKeyDouble) {
   std::string original_key = "KEY";
   double original_value = 3.14159;

--- a/src/test/binary_proto_ostream_writer-test.cpp
+++ b/src/test/binary_proto_ostream_writer-test.cpp
@@ -8,15 +8,20 @@
 #include <fcntl.h>
 #include <random>
 
-// This test instantiates writer/ios explicitely as pointers to control
-// their lifetime s.t. the buffer internal to the writer is flushed
-// correctly prior to attempting a read and so that the writer can flush
-// the iostream buffer correctly.  This is not an efficient way to write
-// to file as there are two layers of buffering.  The correct way to do
-// it is to do a class ("binary_proto_file_writer") that uses a
-// FileOutputStream on the inside as it's ZeroCopyOutputStream type.
-// This is just to have a test.
-//
+/*
+ * These tests instantiate the streams using pointer/new and the writer
+ * using pointer/new in order to control object lifetime and stream
+ * flushing.  This is not the right way to use them in other code where
+ * a stream is flushed on destruction and read by a separate process.
+ * In general the writer should be instantiated as (probably with a
+ * typedef in here somewhere):
+ *
+ * stan::interface_callbacks::writer::binary_proto_stream_writer<stan::proto::write_delimited_pb> writer(ostream);
+ *
+ * where ostream is a ZeroCopyOutputStream (or subclass), here a
+ * OstreamOuptutStream constructed from a std::ostream.  The ostream
+ * must be passed in as a pointer and will be delted by the writer.
+ */
 TEST(binaryProtoOstreamWriter,roundTripKeyDouble) {
   std::string original_key = "KEY";
   double original_value = 3.14159;

--- a/src/test/rw_delimited_pb-test.cpp
+++ b/src/test/rw_delimited_pb-test.cpp
@@ -5,7 +5,31 @@
 #include <protostan/util/rw_delimited_pb.hpp>
 #include <fcntl.h>
 
-
+/*
+ * This is a round-trip test which must control lifetime of the streams
+ * and file descriptors so they are all instantiated as pointers.  The
+ * stream is only flushed when deleted, and for good measure I close the
+ * file after writing and re-open it for reading rather than messing
+ * around with seekg/etc... a simple StanMessage is created, written to the
+ * file, and then the data is read back into a separate StanMessage
+ * before comaprison.
+ *
+ * In typical usage, the stream could be created
+ * without the use of a pointer/new.  So something assuming two
+ * StanMessage types are on hand (pb and pb2), something like:
+ *
+ * mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+ * int fd = open("/tmp/test-rwDelimitedPb.pb", O_CREAT | O_WRONLY | O_TRUNC, mode);
+ * google::protobuf::io::FileOutputStream pb_ostream(fd);
+ * success = stan::proto::write_delimited_pb(&pb, &pb_ostream);
+ * 
+ * The reading example below would be:
+ *
+ * fd = open("/tmp/test-rwDelimitedPb.pb", O_RDONLY); 
+ * google::protobuf::io::FileInputStream pb_istream(fd);
+ * success = stan::proto::read_delimited_pb(&pb2, &pb_istream);
+ *
+ */
 TEST(binaryProtoWriter, rwDelimitedPb) {
   std::string original_key = "KEY";
   std::string original_value = "I AM YOUR STRING";


### PR DESCRIPTION
Also added calls to google::protobuf::Message.Clear() to writer so that when multiple method calls are mixed the message doesn't write cruft from a previous call.
