### PR TITLE
Enumerate .proto files to be transplied

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
   - git submodule update --init --recursive
 script:
   - make cpplint
-  - make test
+  - PROTOC=./lib/protobuf/src/protoc make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+PROTOC ?= protoc
+PROTO_DIR = src/stan/proto
+PROTO_SRCS = $(shell find $(PROTO_DIR) -name "*.proto")
+PROTO_GENERATED = $(subst .proto,.pb.cc,$(PROTO_SRCS))
 
 default: test
 
@@ -5,10 +9,12 @@ libraries: lib/libstanc.a lib/libgtest.a lib/libprotobuf.a
 
 test-binaries: test/unit/compile-test test/unit/rw_delimited_pb-test test/unit/binary_proto_filestream_writer-test test/unit/binary_proto_ostream_writer-test
 
-generated:
-	./lib/protobuf/src/protoc --cpp_out=src/stan/proto --proto_path=src/stan/proto src/stan/proto/*.proto
+generated: $(PROTO_GENERATED)
 
-test: libraries generated test-binaries 
+%.pb.cc: %.proto
+	$(PROTOC) --cpp_out=$(PROTO_DIR) --proto_path=$(PROTO_DIR) $<
+
+test: libraries generated test-binaries
 	@echo running tests
 	test/unit/compile-test
 	test/unit/rw_delimited_pb-test

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Message definitions are found in ``src/stan/proto``.
 Quickstart
 ==========
 
+The directory containing the ``protoc`` binary should be in your ``PATH``
+(e.g., in ``/usr/bin/``) or you can define an environment variable ``PROTOC``
+which points to the binary.
+
 1. Clone repository and submodules
 
 ```


### PR DESCRIPTION
`protoc` now needs to be findable in the current `PATH`.

If `protoc` is not on the current PATH one will need to do something like

`PROTOC=./lib/protobuf/src/protoc make test`

(this is part of the Makefile cleanup)
